### PR TITLE
feat: cadastro de interesse + cálculo de ranking de prioridade

### DIFF
--- a/sam-api/src/main/java/br/ufrn/sam/controller/InteresseController.java
+++ b/sam-api/src/main/java/br/ufrn/sam/controller/InteresseController.java
@@ -1,0 +1,47 @@
+package br.ufrn.sam.controller;
+
+import br.ufrn.sam.model.InteresseModel;
+import br.ufrn.sam.service.InteresseService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/interesses")
+public class InteresseController {
+
+    private final InteresseService interesseService;
+
+    public InteresseController(InteresseService interesseService) {
+        this.interesseService = interesseService;
+    }
+
+    // POST /api/interesses/{matricula}/{codigoTurma} → registra interesse
+    @PostMapping("/{matricula}/{codigoTurma}")
+    public ResponseEntity<InteresseModel> cadastrar(
+            @PathVariable String matricula,
+            @PathVariable String codigoTurma) {
+        InteresseModel salvo = interesseService.cadastrar(matricula, codigoTurma);
+        return ResponseEntity.status(HttpStatus.CREATED).body(salvo);
+    }
+
+    // GET /api/interesses/aluno/{matricula} → lista interesses de um aluno
+    @GetMapping("/aluno/{matricula}")
+    public ResponseEntity<List<InteresseModel>> listarPorAluno(@PathVariable String matricula) {
+        return ResponseEntity.ok(interesseService.listarPorAluno(matricula));
+    }
+
+    // GET /api/interesses/turma/{codigoTurma} → lista interessados em uma turma
+    @GetMapping("/turma/{codigoTurma}")
+    public ResponseEntity<List<InteresseModel>> listarPorTurma(@PathVariable String codigoTurma) {
+        return ResponseEntity.ok(interesseService.listarPorTurma(codigoTurma));
+    }
+
+    // GET /api/interesses → lista todos
+    @GetMapping
+    public ResponseEntity<List<InteresseModel>> listarTodos() {
+        return ResponseEntity.ok(interesseService.listarTodos());
+    }
+}

--- a/sam-api/src/main/java/br/ufrn/sam/model/AlunoModel.java
+++ b/sam-api/src/main/java/br/ufrn/sam/model/AlunoModel.java
@@ -2,6 +2,8 @@ package br.ufrn.sam.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -11,7 +13,6 @@ import jakarta.persistence.Table;
 @Table(name = "aluno")
 public class AlunoModel extends PessoaModel {
 
-   
     private int idAluno;
 
     @Column(nullable = false, unique = true)
@@ -32,12 +33,33 @@ public class AlunoModel extends PessoaModel {
     @Column(nullable = false)
     private Boolean isConcluinte;
 
+    //Campos de Ranking de Prioridade 
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NivelPrioridade nivelPrioridade;
+
+    @Column(nullable = false)
+    private Boolean ingressoVestibularPrimeiroPeriodo;
+
+    //Perfil inicial: período de ingresso previsto na matriz curricular do aluno
+    @Column
+    private Integer perfilInicial;
+
+    //Períodos letivos regulares cursados, excluindo trancamentos/mobilidade 
+    @Column
+    private Integer periodosRegularesCursados;
+
     public AlunoModel() {}
 
     public AlunoModel(String login, String senha, Boolean isAluno,
                       String matricula, String nome,
                       Double iea, Double ira,
-                      Integer periodo, Boolean isConcluinte) {
+                      Integer periodo, Boolean isConcluinte,
+                      NivelPrioridade nivelPrioridade,
+                      Boolean ingressoVestibularPrimeiroPeriodo,
+                      Integer perfilInicial,
+                      Integer periodosRegularesCursados) {
         super(login, senha, isAluno);
         this.matricula = matricula;
         this.nome = nome;
@@ -45,6 +67,10 @@ public class AlunoModel extends PessoaModel {
         this.ira = ira;
         this.periodo = periodo;
         this.isConcluinte = isConcluinte;
+        this.nivelPrioridade = nivelPrioridade;
+        this.ingressoVestibularPrimeiroPeriodo = ingressoVestibularPrimeiroPeriodo;
+        this.perfilInicial = perfilInicial;
+        this.periodosRegularesCursados = periodosRegularesCursados;
     }
 
     public int getIdAluno() { return idAluno; }
@@ -67,4 +93,30 @@ public class AlunoModel extends PessoaModel {
 
     public Boolean getIsConcluinte() { return isConcluinte; }
     public void setIsConcluinte(Boolean isConcluinte) { this.isConcluinte = isConcluinte; }
+
+    public NivelPrioridade getNivelPrioridade() { return nivelPrioridade; }
+    public void setNivelPrioridade(NivelPrioridade nivelPrioridade) { this.nivelPrioridade = nivelPrioridade; }
+
+    public Boolean getIngressoVestibularPrimeiroPeriodo() { return ingressoVestibularPrimeiroPeriodo; }
+    public void setIngressoVestibularPrimeiroPeriodo(Boolean ingressoVestibularPrimeiroPeriodo) {
+        this.ingressoVestibularPrimeiroPeriodo = ingressoVestibularPrimeiroPeriodo;
+    }
+
+    public Integer getPerfilInicial() { return perfilInicial; }
+    public void setPerfilInicial(Integer perfilInicial) { this.perfilInicial = perfilInicial; }
+
+    public Integer getPeriodosRegularesCursados() { return periodosRegularesCursados; }
+    public void setPeriodosRegularesCursados(Integer periodosRegularesCursados) {
+        this.periodosRegularesCursados = periodosRegularesCursados;
+    }
+
+    /**
+     * Soma usada no critério de desempate do §2º, aplicável aos níveis I, III e IV.
+     * Retorna 0 se algum dos valores não estiver informado, para não quebrar o ranking.
+     */
+    public int getPontuacaoDesempateNivel() {
+        int perfil = perfilInicial != null ? perfilInicial : 0;
+        int cursados = periodosRegularesCursados != null ? periodosRegularesCursados : 0;
+        return perfil + cursados;
+    }
 }

--- a/sam-api/src/main/java/br/ufrn/sam/model/AlunoModel.java
+++ b/sam-api/src/main/java/br/ufrn/sam/model/AlunoModel.java
@@ -111,7 +111,7 @@ public class AlunoModel extends PessoaModel {
     }
 
     /**
-     * Soma usada no critério de desempate do §2º, aplicável aos níveis I, III e IV.
+     * Soma usada no critério de desempate, aplicável aos níveis I, III e IV.
      * Retorna 0 se algum dos valores não estiver informado, para não quebrar o ranking.
      */
     public int getPontuacaoDesempateNivel() {

--- a/sam-api/src/main/java/br/ufrn/sam/model/DisciplinaModel.java
+++ b/sam-api/src/main/java/br/ufrn/sam/model/DisciplinaModel.java
@@ -23,14 +23,20 @@ public class DisciplinaModel {
 
     @Column(nullable = false)
     private Integer chTotal;
+    
+    //para saber se é uma disciplina de primeiro nivel da estrutura curricular do aluno (semestre)
+    @Column(nullable = false)
+    private Boolean primeiroNivel;
 
     public DisciplinaModel() {}
 
-    public DisciplinaModel(String codigo, String nome, Integer chTotal) {
+    public DisciplinaModel(String codigo, String nome, Integer chTotal, boolean primeiroNivel) {
         this.codigo = codigo;
         this.nome = nome;
         this.chTotal = chTotal;
+        this.primeiroNivel = primeiroNivel;
     }
+    
 
     public Integer getIdDisciplina() { return idDisciplina; }
     public void setIdDisciplina(Integer idDisciplina) { this.idDisciplina = idDisciplina; }
@@ -43,4 +49,7 @@ public class DisciplinaModel {
 
     public Integer getChTotal() { return chTotal; }
     public void setChTotal(Integer chTotal) { this.chTotal = chTotal; }
+    
+    public Boolean getPrimeiroNivel() { return primeiroNivel; }
+    public void setPrimeiroNivel(Boolean primeiroNivel) { this.primeiroNivel = primeiroNivel; }
 }

--- a/sam-api/src/main/java/br/ufrn/sam/model/InteresseModel.java
+++ b/sam-api/src/main/java/br/ufrn/sam/model/InteresseModel.java
@@ -1,0 +1,62 @@
+package br.ufrn.sam.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+    name = "interesse",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"aluno_id", "turma_id"})
+    // garante que um aluno não pode se interessar pela mesma turma duas vezes
+)
+public class InteresseModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer idInteresse;
+
+    @Column(nullable = false)
+    private String dataRegistro;
+
+    @Column
+    private Integer posicaoLista;
+
+    @ManyToOne
+    @JoinColumn(name = "aluno_id", nullable = false)
+    private AlunoModel aluno;
+
+    @ManyToOne
+    @JoinColumn(name = "turma_id", nullable = false)
+    private TurmaModel turma;
+
+    public InteresseModel() {}
+
+    public InteresseModel(String dataRegistro, Integer posicaoLista, AlunoModel aluno, TurmaModel turma) {
+        this.dataRegistro = dataRegistro;
+        this.posicaoLista = posicaoLista;
+        this.aluno = aluno;
+        this.turma = turma;
+    }
+
+    public Integer getIdInteresse() { return idInteresse; }
+    public void setIdInteresse(Integer idInteresse) { this.idInteresse = idInteresse; }
+
+    public String getDataRegistro() { return dataRegistro; }
+    public void setDataRegistro(String dataRegistro) { this.dataRegistro = dataRegistro; }
+
+    public Integer getPosicaoLista() { return posicaoLista; }
+    public void setPosicaoLista(Integer posicaoLista) { this.posicaoLista = posicaoLista; }
+
+    public AlunoModel getAluno() { return aluno; }
+    public void setAluno(AlunoModel aluno) { this.aluno = aluno; }
+
+    public TurmaModel getTurma() { return turma; }
+    public void setTurma(TurmaModel turma) { this.turma = turma; }
+}

--- a/sam-api/src/main/java/br/ufrn/sam/model/NivelPrioridade.java
+++ b/sam-api/src/main/java/br/ufrn/sam/model/NivelPrioridade.java
@@ -1,0 +1,22 @@
+package br.ufrn.sam.model;
+
+/**
+ * Legenda de Prioridades:
+ * I    - Aluno Nivelado
+ * II   - Aluno Pré-concluinte
+ * III  - Aluno em Recuperação
+ * IIIE - Aluno em Recuperação com prioridade (III*)
+ * IV   - Aluno Adiantado
+ * V    - Aluno cursando componente eletivo
+ *
+ * A ordem dos valores no enum reflete a ordem de prioridade:
+ * quanto menor o ordinal, maior a prioridade.
+ */
+public enum NivelPrioridade {
+    NIVEL_I,
+    NIVEL_II,
+    NIVEL_III,
+    NIVEL_III_PRIORIDADE,
+    NIVEL_IV,
+    NIVEL_V
+}

--- a/sam-api/src/main/java/br/ufrn/sam/repository/JpaInteresseRepository.java
+++ b/sam-api/src/main/java/br/ufrn/sam/repository/JpaInteresseRepository.java
@@ -1,0 +1,13 @@
+package br.ufrn.sam.repository;
+
+import br.ufrn.sam.model.InteresseModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface JpaInteresseRepository extends JpaRepository<InteresseModel, Integer> {
+    List<InteresseModel> findByAlunoIdAluno(Integer idAluno);
+    List<InteresseModel> findByTurmaIdTurma(Integer idTurma);
+}

--- a/sam-api/src/main/java/br/ufrn/sam/service/InteresseRankingComparator.java
+++ b/sam-api/src/main/java/br/ufrn/sam/service/InteresseRankingComparator.java
@@ -1,0 +1,63 @@
+package br.ufrn.sam.service;
+
+import br.ufrn.sam.model.AlunoModel;
+import br.ufrn.sam.model.InteresseModel;
+import br.ufrn.sam.model.NivelPrioridade;
+
+import java.util.Comparator;
+
+/**
+ * Ordena InteresseModel de uma mesma turma conforme a Legenda de Prioridades:
+ *
+ * 1) §1º - Prioridade absoluta: aluno com ingresso por vestibular no primeiro
+ *    período letivo tem prioridade máxima para componentes do primeiro nível
+ *    da estrutura curricular (disciplina.primeiroNivel == true).
+ * 2) Nível de prioridade (I, II, III, III*, IV, V), conforme ordem do enum
+ *    NivelPrioridade (menor ordinal = maior prioridade).
+ * 3) §3º - Desempate final: maior IEA vence.
+ */
+public class InteresseRankingComparator implements Comparator<InteresseModel> {
+
+    @Override
+    public int compare(InteresseModel i1, InteresseModel i2) {
+        AlunoModel a1 = i1.getAluno();
+        AlunoModel a2 = i2.getAluno();
+
+        // 1) Prioridade absoluta do §1º
+        boolean prioridadeAbsoluta1 = temPrioridadeAbsoluta(i1);
+        boolean prioridadeAbsoluta2 = temPrioridadeAbsoluta(i2);
+        if (prioridadeAbsoluta1 != prioridadeAbsoluta2) {
+            // quem tem prioridade absoluta (true) vem primeiro
+            return prioridadeAbsoluta1 ? -1 : 1;
+        }
+
+        // 2) Nível de prioridade (menor ordinal = maior prioridade)
+        int comparacaoNivel = compararNivel(a1.getNivelPrioridade(), a2.getNivelPrioridade());
+        if (comparacaoNivel != 0) {
+            return comparacaoNivel;
+        }
+
+        // 3) Desempate final do §3º: maior IEA vence
+        double iea1 = a1.getIea() != null ? a1.getIea() : 0.0;
+        double iea2 = a2.getIea() != null ? a2.getIea() : 0.0;
+        return Double.compare(iea2, iea1); // maior IEA vence -> ordem decrescente
+    }
+
+    private boolean temPrioridadeAbsoluta(InteresseModel interesse) {
+        AlunoModel aluno = interesse.getAluno();
+        boolean disciplinaPrimeiroNivel = interesse.getTurma() != null
+                && interesse.getTurma().getDisciplina() != null
+                && Boolean.TRUE.equals(interesse.getTurma().getDisciplina().getPrimeiroNivel());
+
+        boolean alunoVestibularPrimeiroPeriodo = Boolean.TRUE.equals(aluno.getIngressoVestibularPrimeiroPeriodo());
+
+        return disciplinaPrimeiroNivel && alunoVestibularPrimeiroPeriodo;
+    }
+
+    private int compararNivel(NivelPrioridade nivel1, NivelPrioridade nivel2) {
+        if (nivel1 == null && nivel2 == null) return 0;
+        if (nivel1 == null) return 1;  // nível ausente vai para o final
+        if (nivel2 == null) return -1;
+        return Integer.compare(nivel1.ordinal(), nivel2.ordinal());
+    }
+}

--- a/sam-api/src/main/java/br/ufrn/sam/service/InteresseService.java
+++ b/sam-api/src/main/java/br/ufrn/sam/service/InteresseService.java
@@ -1,0 +1,69 @@
+package br.ufrn.sam.service;
+
+import br.ufrn.sam.model.AlunoModel;
+import br.ufrn.sam.model.InteresseModel;
+import br.ufrn.sam.model.TurmaModel;
+import br.ufrn.sam.repository.JpaAlunoRepository;
+import br.ufrn.sam.repository.JpaInteresseRepository;
+import br.ufrn.sam.repository.JpaTurmaRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+public class InteresseService {
+
+    private final JpaInteresseRepository interesseRepository;
+    private final JpaAlunoRepository alunoRepository;
+    private final JpaTurmaRepository turmaRepository;
+
+    public InteresseService(JpaInteresseRepository interesseRepository,
+                            JpaAlunoRepository alunoRepository,
+                            JpaTurmaRepository turmaRepository) {
+        this.interesseRepository = interesseRepository;
+        this.alunoRepository = alunoRepository;
+        this.turmaRepository = turmaRepository;
+    }
+
+    public InteresseModel cadastrar(Integer idAluno, Integer idTurma) {
+        // busca o aluno pelo id
+        AlunoModel aluno = alunoRepository.findById(idAluno)
+                .orElseThrow(() -> new NoSuchElementException("Aluno não encontrado: " + idAluno));
+
+        // busca a turma pelo id
+        TurmaModel turma = turmaRepository.findById(idTurma)
+                .orElseThrow(() -> new NoSuchElementException("Turma não encontrada: " + idTurma));
+
+        // verifica se já existe interesse do aluno nessa turma
+        if (!interesseRepository.findByAlunoIdAluno(idAluno).isEmpty()) {
+            List<InteresseModel> interesses = interesseRepository.findByAlunoIdAluno(idAluno);
+            for (InteresseModel i : interesses) {
+                if (i.getTurma().getIdTurma().equals(idTurma)) {
+                    throw new IllegalArgumentException("Aluno já manifestou interesse nessa turma!");
+                }
+            }
+        }
+
+        InteresseModel interesse = new InteresseModel(
+                java.time.LocalDate.now().toString(),
+                null,
+                aluno,
+                turma
+        );
+
+        return interesseRepository.save(interesse);
+    }
+
+    public List<InteresseModel> listarPorAluno(Integer idAluno) {
+        return interesseRepository.findByAlunoIdAluno(idAluno);
+    }
+
+    public List<InteresseModel> listarPorTurma(Integer idTurma) {
+        return interesseRepository.findByTurmaIdTurma(idTurma);
+    }
+
+    public List<InteresseModel> listarTodos() {
+        return interesseRepository.findAll();
+    }
+}

--- a/sam-api/src/main/java/br/ufrn/sam/service/InteresseService.java
+++ b/sam-api/src/main/java/br/ufrn/sam/service/InteresseService.java
@@ -26,22 +26,20 @@ public class InteresseService {
         this.turmaRepository = turmaRepository;
     }
 
-    public InteresseModel cadastrar(Integer idAluno, Integer idTurma) {
-        // busca o aluno pelo id
-        AlunoModel aluno = alunoRepository.findById(idAluno)
-                .orElseThrow(() -> new NoSuchElementException("Aluno não encontrado: " + idAluno));
+    public InteresseModel cadastrar(String matricula, String codigoTurma) {
+        // busca o aluno pela matrícula
+        AlunoModel aluno = alunoRepository.findByMatricula(matricula)
+                .orElseThrow(() -> new NoSuchElementException("Aluno não encontrado: " + matricula));
 
-        // busca a turma pelo id
-        TurmaModel turma = turmaRepository.findById(idTurma)
-                .orElseThrow(() -> new NoSuchElementException("Turma não encontrada: " + idTurma));
+        // busca a turma pelo código
+        TurmaModel turma = turmaRepository.findByCodigo(codigoTurma)
+                .orElseThrow(() -> new NoSuchElementException("Turma não encontrada: " + codigoTurma));
 
         // verifica se já existe interesse do aluno nessa turma
-        if (!interesseRepository.findByAlunoIdAluno(idAluno).isEmpty()) {
-            List<InteresseModel> interesses = interesseRepository.findByAlunoIdAluno(idAluno);
-            for (InteresseModel i : interesses) {
-                if (i.getTurma().getIdTurma().equals(idTurma)) {
-                    throw new IllegalArgumentException("Aluno já manifestou interesse nessa turma!");
-                }
+        List<InteresseModel> interesses = interesseRepository.findByAlunoIdAluno(aluno.getIdAluno());
+        for (InteresseModel i : interesses) {
+            if (i.getTurma().getCodigo().equals(codigoTurma)) {
+                throw new IllegalArgumentException("Aluno já manifestou interesse nessa turma!");
             }
         }
 
@@ -55,12 +53,16 @@ public class InteresseService {
         return interesseRepository.save(interesse);
     }
 
-    public List<InteresseModel> listarPorAluno(Integer idAluno) {
-        return interesseRepository.findByAlunoIdAluno(idAluno);
+    public List<InteresseModel> listarPorAluno(String matricula) {
+        AlunoModel aluno = alunoRepository.findByMatricula(matricula)
+                .orElseThrow(() -> new NoSuchElementException("Aluno não encontrado: " + matricula));
+        return interesseRepository.findByAlunoIdAluno(aluno.getIdAluno());
     }
 
-    public List<InteresseModel> listarPorTurma(Integer idTurma) {
-        return interesseRepository.findByTurmaIdTurma(idTurma);
+    public List<InteresseModel> listarPorTurma(String codigoTurma) {
+        TurmaModel turma = turmaRepository.findByCodigo(codigoTurma)
+                .orElseThrow(() -> new NoSuchElementException("Turma não encontrada: " + codigoTurma));
+        return interesseRepository.findByTurmaIdTurma(turma.getIdTurma());
     }
 
     public List<InteresseModel> listarTodos() {

--- a/sam-api/src/main/java/br/ufrn/sam/service/InteresseService.java
+++ b/sam-api/src/main/java/br/ufrn/sam/service/InteresseService.java
@@ -62,9 +62,14 @@ public class InteresseService {
     public List<InteresseModel> listarPorTurma(String codigoTurma) {
         TurmaModel turma = turmaRepository.findByCodigo(codigoTurma)
                 .orElseThrow(() -> new NoSuchElementException("Turma não encontrada: " + codigoTurma));
-        return interesseRepository.findByTurmaIdTurma(turma.getIdTurma());
-    }
 
+        List<InteresseModel> interesses = interesseRepository.findByTurmaIdTurma(turma.getIdTurma());
+
+        interesses.sort(new InteresseRankingComparator());
+
+        return interesses;
+    }
+    
     public List<InteresseModel> listarTodos() {
         return interesseRepository.findAll();
     }


### PR DESCRIPTION
Implementa o cadastro de interesse do aluno em uma turma e a lógica de ranking de prioridade na listagem por turma

O que foi feito

Cadastro de Interesse

- InteresseModel com anotações JPA
- JpaInteresseRepository
- InteresseService
- InteresseController

Ranking de Prioridade:

- NivelPrioridade (novo enum): representa os níveis I, II, III, III*, IV, V. A ordem de declaração reflete a ordem de prioridade (menor ordinal = maior prioridade).
- AlunoModel: adicionados os campos nivelPrioridade, ingressoVestibularPrimeiroPeriodo, perfilInicial e periodosRegularesCursados, autoinformados pelo próprio aluno no cadastro.
- DisciplinaModel: adicionado o campo primeiroNivel, indicando se a disciplina pertence ao primeiro nível da estrutura curricular do curso (usado na regra do §1º).
- InteresseRankingComparator (novo): implementa a ordenação em cascata:
        - §1º — prioridade absoluta para aluno com ingresso por vestibular no primeiro período letivo, em turma de disciplina de primeiro nível
        - Nível de prioridade (ordem do enum NivelPrioridade)
        - §3º — desempate final por IEA (maior IEA vence)

- InteresseService.listarPorTurma: agora ordena a lista de interessados com o InteresseRankingComparator antes de retornar.